### PR TITLE
Fixed issue that caused module-level functions from being called properly

### DIFF
--- a/auger/generator/default.py
+++ b/auger/generator/default.py
@@ -153,7 +153,10 @@ class DefaultGenerator(Generator):
         definer, member = self.get_defining_item(code)
         for (args, return_value) in call:
             func_self = args.get('self')
+            is_func   = inspect.isfunction(member)
+            is_method = inspect.ismethod(member)
             is_static = isinstance(definer.__dict__.get(runtime.get_code_name(code)), staticmethod)
+            is_mod    = isinstance(definer, types.ModuleType)
             if isinstance(member, property) or inspect.ismethod(member):
                 if not is_static:
                     typename, init, init_args = self.get_instance(self.instances, func_self)
@@ -174,14 +177,14 @@ class DefaultGenerator(Generator):
             # print 'member: ', member
             # print 'target: ', target
             # print 'name:   ', runtime.get_code_name(code)
-            # print 'ismod?: ', isinstance(definer, types.ModuleType)
+            # print 'ismod?: ', is_mod
             # print 'static?:', is_static
-            # print 'method?:', inspect.ismethod(member)
-            # print 'func?:  ', inspect.isfunction(member)
+            # print 'method?:', is_method
+            # print 'func?:  ', is_func
             # print '-' * 80
 
             call = '%s.%s' % (target, runtime.get_code_name(code))
-            if inspect.ismethod(member) or inspect.isfunction(member) or is_static:
+            if is_method or is_func or is_static or is_mod:
                 call += '(%s)' % (
                     ','.join(['%s=%s' % (k, repr(v)) for k, v in args.items()]),
                 )

--- a/sample/functions.py
+++ b/sample/functions.py
@@ -1,0 +1,18 @@
+import os
+
+def func_one():
+    return os.path.exists('C:/temp')
+
+def func_two(a):
+    return os.path.isdir(a)
+
+def func_three(a):
+    return func_two(a)
+
+def main():
+    print func_one()
+    print func_two('C:/temp')
+    print func_three('C:/temp')
+
+if __name__ == '__main__':
+    main()

--- a/sample/gentests.py
+++ b/sample/gentests.py
@@ -2,8 +2,10 @@ import auger
 import main, animal, pet
 import foo
 import properties
+import functions
 
-with auger.magic([animal, pet, foo.Foo, properties.Language]):
+with auger.magic([animal, pet, foo.Foo, properties.Language, functions]):
     main.main()
     foo.main()
     properties.main()
+    functions.main()

--- a/sample/tests/test_Foo.py
+++ b/sample/tests/test_Foo.py
@@ -3,7 +3,11 @@ from animal import Animal
 import foo
 from foo import Bar
 from foo import Foo
+import functions
+import genericpath
+from genericpath import unicode
 from mock import patch
+import os
 import pet
 from pet import Animal
 from pet import Pet

--- a/sample/tests/test_functions.py
+++ b/sample/tests/test_functions.py
@@ -1,0 +1,52 @@
+import animal
+from animal import Animal
+import functions
+import genericpath
+from genericpath import unicode
+from mock import patch
+import os
+import pet
+from pet import Animal
+from pet import Pet
+import properties
+from properties import Language
+import random
+from random import Random
+import unittest
+
+
+class FunctionsTest(unittest.TestCase):
+    @patch.object(genericpath, 'exists')
+    def test_func_one(self, mock_exists):
+        mock_exists.return_value = False
+        self.assertEqual(
+            functions.func_one(),
+            False
+        )
+
+
+    def test_func_three(self):
+        self.assertEqual(
+            functions.func_three(a='C:/temp'),
+            False
+        )
+
+
+    @patch.object(genericpath, 'isdir')
+    def test_func_two(self, mock_isdir):
+        mock_isdir.return_value = False
+        self.assertEqual(
+            functions.func_two(a='C:/temp'),
+            False
+        )
+
+
+    def test_main(self):
+        self.assertEqual(
+            functions.main(),
+            None
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixed issue that caused module-level functions from being called properly in generated test cases. 

Before this fix, the output in test_functions was for example:

```
        self.assertEqual(
            functions.func_two,
            False
        )
```

After this patch, it will generate:
```
        self.assertEqual(
            functions.func_two(a='C:/temp'),
            False
        )
```

All other tests seem to be untouched.