### PR TITLE
Multiple imports after the from keyword are not handled correctly

### DIFF
--- a/auger/generator/default.py
+++ b/auger/generator/default.py
@@ -31,7 +31,10 @@ class DefaultGenerator(Generator):
             if line.startswith('import '):
                 self.add_import(line.replace('import ', ''))
             if line.startswith('from '):
-                self.add_import(*(line.replace('from ', '').replace('import ','').split(' ')))
+                module  = line.replace('from ', '').split(' import')[0]
+                imports = [import_.strip() for import_ in line.split('import ')[1].split(',')]
+                for import_ in imports:
+                    self.add_import(module, import_)
         return '\n'.join(self.format_imports() + self.output_)
 
     def format_imports(self):


### PR DESCRIPTION
The previous code assumed that there would always be exactly one import listed in a "from ... import ..." statement.

This fix allows multiple imports to be specified.